### PR TITLE
[FIX] versions ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 .idea/
 node_modules/
+test
+.env
+index-local.js
+

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const baseUrl = core.getInput('baseUrl');
 const basePdf = core.getInput('basePdf');
 const pdfName = core.getInput('pdfName');
 
+
 const s3 = new S3({
     region: core.getInput('region'),
     accessKeyId: core.getInput('accessKeyId'),
@@ -50,7 +51,6 @@ async function getVersion(type) {
 }
 
 async function getAsset(file) {
-    console.log({file})
     const params = {
         Bucket,
         Key: `assets/${file}`,
@@ -190,15 +190,15 @@ async function generatePdf() {
         shortVersion: await getVersion('short'),
         releaseDate: await getReleaseDate(),
         previousFiles: mapped,
-        manufacturer: readFileSync('src/assets/manufacturer.png').toString('base64'),
-        dateManufacturer: readFileSync('/.assets/dateManufacturer.png').toString('base64'),
-        ref: readFileSync('src/assets/ref.png').toString('base64'),
-        lot: readFileSync('src/assets/lot.png').toString('base64'),
-        udi: readFileSync('src/assets/udi.png').toString('base64'),
-        ukca: readFileSync('src/assets/ukca.png').toString('base64'),
-        caution: readFileSync('src/assets/caution.png').toString('base64'),
-        eifu: readFileSync('src/assets/eifu.png').toString('base64'),
-        logo: readFileSync('src/assets/logo.png').toString('base64'),
+        manufacturer: readFileSync('/assets/manufacturer.png').toString('base64'),
+        dateManufacturer: readFileSync('/assets/dateManufacturer.png').toString('base64'),
+        ref: readFileSync('/assets/ref.png').toString('base64'),
+        lot: readFileSync('/assets/lot.png').toString('base64'),
+        udi: readFileSync('/assets/udi.png').toString('base64'),
+        ukca: readFileSync('/assets/ukca.png').toString('base64'),
+        caution: readFileSync('/assets/caution.png').toString('base64'),
+        eifu: readFileSync('/assets/eifu.png').toString('base64'),
+        logo: readFileSync('/assets/logo.png').toString('base64'),
     });
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -140,14 +140,16 @@ async function mapAllFiles(currentPdfName) {
     previousFiles.forEach((item) => {
         const build = item.split('-')[0];
         const date = item.match(/\d{2}-\d{2}-\d{4}/)[0];
-        mapped.push({ build, date });
+        mapped.push({build, date});
     });
 
     // Sort versions numerically
     mapped.sort((a, b) => {
-        const versionA = a.build.replace(/^v/, '').split('.').map(Number);
-        const versionB = b.build.replace(/^v/, '').split('.').map(Number);
+        // Extract the version numbers from the strings
+        const versionA = a.build.split('-')[0].split('.').map(Number);
+        const versionB = b.build.split('-')[0].split('.').map(Number);
 
+        // Compare each part of the version number
         for (let i = 0; i < Math.max(versionA.length, versionB.length); i++) {
             const numA = versionA[i] || 0;
             const numB = versionB[i] || 0;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ const baseUrl = core.getInput('baseUrl');
 const basePdf = core.getInput('basePdf');
 const pdfName = core.getInput('pdfName');
 
-
 const s3 = new S3({
     region: core.getInput('region'),
     accessKeyId: core.getInput('accessKeyId'),
@@ -51,6 +50,7 @@ async function getVersion(type) {
 }
 
 async function getAsset(file) {
+    console.log({file})
     const params = {
         Bucket,
         Key: `assets/${file}`,
@@ -138,7 +138,24 @@ async function mapAllFiles(currentPdfName) {
     const mapped = [];
 
     previousFiles.forEach((item) => {
-        mapped.push({build: item.split('-')[0], date: item.match(/\d{2}-\d{2}-\d{4}/)[0]});
+        const build = item.split('-')[0];
+        const date = item.match(/\d{2}-\d{2}-\d{4}/)[0];
+        mapped.push({ build, date });
+    });
+
+    // Sort versions numerically
+    mapped.sort((a, b) => {
+        const versionA = a.build.replace(/^v/, '').split('.').map(Number);
+        const versionB = b.build.replace(/^v/, '').split('.').map(Number);
+
+        for (let i = 0; i < Math.max(versionA.length, versionB.length); i++) {
+            const numA = versionA[i] || 0;
+            const numB = versionB[i] || 0;
+            if (numA !== numB) {
+                return numA - numB;
+            }
+        }
+        return 0;
     });
 
     return mapped;
@@ -173,15 +190,15 @@ async function generatePdf() {
         shortVersion: await getVersion('short'),
         releaseDate: await getReleaseDate(),
         previousFiles: mapped,
-        manufacturer: readFileSync('/assets/manufacturer.png').toString('base64'),
-        dateManufacturer: readFileSync('/assets/dateManufacturer.png').toString('base64'),
-        ref: readFileSync('/assets/ref.png').toString('base64'),
-        lot: readFileSync('/assets/lot.png').toString('base64'),
-        udi: readFileSync('/assets/udi.png').toString('base64'),
-        ukca: readFileSync('/assets/ukca.png').toString('base64'),
-        caution: readFileSync('/assets/caution.png').toString('base64'),
-        eifu: readFileSync('/assets/eifu.png').toString('base64'),
-        logo: readFileSync('/assets/logo.png').toString('base64'),
+        manufacturer: readFileSync('src/assets/manufacturer.png').toString('base64'),
+        dateManufacturer: readFileSync('/.assets/dateManufacturer.png').toString('base64'),
+        ref: readFileSync('src/assets/ref.png').toString('base64'),
+        lot: readFileSync('src/assets/lot.png').toString('base64'),
+        udi: readFileSync('src/assets/udi.png').toString('base64'),
+        ukca: readFileSync('src/assets/ukca.png').toString('base64'),
+        caution: readFileSync('src/assets/caution.png').toString('base64'),
+        eifu: readFileSync('src/assets/eifu.png').toString('base64'),
+        logo: readFileSync('src/assets/logo.png').toString('base64'),
     });
 
     /**


### PR DESCRIPTION
Comparing version names as number instead of string so that order is correct in generated pdf

Currently it looks like: 
<img width="374" alt="Screenshot 2024-08-12 at 09 51 59" src="https://github.com/user-attachments/assets/d455b347-e05e-4ffd-aea6-0b5bfbad5bf3">
<img width="500" alt="Screenshot 2024-08-12 at 09 52 04" src="https://github.com/user-attachments/assets/4c6bb260-7f18-42e3-91f6-e6a7ddb50516">


Locally generated for testing:
[3.38.1-12-08-2024.pdf](https://github.com/user-attachments/files/16580030/3.38.1-12-08-2024.pdf)

